### PR TITLE
Update usage of Akk.actor 1

### DIFF
--- a/freeplane_plugin_remote_client/src/org/freeplane/plugin/remote/client/ClientController.java
+++ b/freeplane_plugin_remote_client/src/org/freeplane/plugin/remote/client/ClientController.java
@@ -27,7 +27,7 @@ import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.actor.TypedProps;
 import akka.actor.UntypedActorFactory;
 import akka.japi.Creator;


### PR DESCRIPTION
Akka.actor.TypedActor has been deprecated as of 2.6.0 in favor of the akka.actor.typed API which should be used instead.

[_Created by Sourcegraph batch change `christine/update-akka-scala-1`._](https://demo.sourcegraph.com/users/christine/batch-changes/update-akka-scala-1)