### PR TITLE
Remove empty catch statement

### DIFF
--- a/Jabref_Beta_2_7_Docear/src/java/tests/net/sf/jabref/testutils/TestUtils.java
+++ b/Jabref_Beta_2_7_Docear/src/java/tests/net/sf/jabref/testutils/TestUtils.java
@@ -26,7 +26,6 @@ public class TestUtils {
 		try {
 			String[] args = { "-p", " ", PATH_TO_TEST_BIBTEX };
 			JabRef.main(args);
-		} catch (ExitException e) {
 		} finally {
 			enableSystemExit();
 		}

--- a/docear_plugin_core/src/org/docear/plugin/core/features/DocearThread.java
+++ b/docear_plugin_core/src/org/docear/plugin/core/features/DocearThread.java
@@ -18,10 +18,7 @@ public abstract class DocearThread extends Thread {
 		try {
 			DocearController.getController().addWorkingThreadHandle(threadID);
 			this.execute();
-		} 
-		catch (InterruptedException e) {
-		}
-		finally {
+		} finally {
 			DocearController.getController().removeWorkingThreadHandle(threadID);
 		}
 	}

--- a/freeplane/src/org/freeplane/main/application/ApplicationResourceController.java
+++ b/freeplane/src/org/freeplane/main/application/ApplicationResourceController.java
@@ -247,10 +247,7 @@ public class ApplicationResourceController extends ResourceController {
 			outputStreamWriter.write('\n');
 			outputStreamWriter.flush();
 			props.store(out, null);
-		}
-		catch (final Exception ex) {
-		}
-		finally {
+		} finally {
 			if (out != null) {
 				try {
 					out.close();


### PR DESCRIPTION
Find try-catch-finally statements where the catch statement has no body (the catch clause could be omitted)

[_Created by Sourcegraph batch change `christine/java-remove-catch-2`._](https://demo.sourcegraph.com/users/christine/batch-changes/java-remove-catch-2)